### PR TITLE
Nonblocking initial page

### DIFF
--- a/i18n/en.msgs
+++ b/i18n/en.msgs
@@ -37,9 +37,10 @@ prefs_langlabel Interface language:
 
 # DoReport messages
 report_wascached This report was cached %(age)s ago.
-report_cold_cache_running Cache regeneration started %(runtime)s ago.
-report_cold_cache_started Cache regeneration has just started.
+report_cold_cache_running Cache (re)generation started %(runtime)s ago.
+report_cold_cache_started Cache (re)generation has just started.
 report_nocache This report is scheduled to be regenerated nightly, but hasn't been run yet, so there is no data available.
+report_first_run This report is being generated for the first time, so no data is available yet.
 report_variables_used The following variables were used to generate this report:
 report_variable %(name)s: %(value)s
 report_noresults Sorry, this report produced no results.

--- a/python/DoReportPage.py
+++ b/python/DoReportPage.py
@@ -61,8 +61,12 @@ def response(context, req):
     cache = QueryCache(context)
     cache_result = cache.execute(report, dbname, variables)
     status = cache_result['status']
-    if status == 'unavailable':
+    if status == 'unavailable' or status == 'first':
         t = req.prepare_template(CachedReportUnavailable)
+        t.status = status
+        if status == 'first':
+            t.query_runtime = cache_result['query runtime']
+
         t.report = report
         output = str(t)
         req.start_response('200 OK', [('Content-Type', 'text/html; charset=UTF-8')])

--- a/python/QueryCache.py
+++ b/python/QueryCache.py
@@ -89,9 +89,15 @@ class QueryCache:
                     return {'status': 'cold', 'query runtime': query_runtime, 
                             'age': age, 'result': result}
 
-            # Not cached; if it's a nightly query, return failure
+            # No cached value exists; if it's a nightly query, return failure
             if report.nightly:
                 return {'status': 'unavailable'}
+            else:
+                query_runtime = self.run_background_update(dbname, report, variables)
+                return {'status': 'first', 'query runtime': query_runtime, 
+                        'age': age, 'result': result}
+
+               
 
         result = self.update_report(dbname, report, variables)
         return {'status': 'fresh', 'age': 0, 'result': result}

--- a/python/templates/CachedReportUnavailable.tmpl
+++ b/python/templates/CachedReportUnavailable.tmpl
@@ -17,7 +17,18 @@ $i18n.report_name($report)
 #end def
 
 #def body
-	<p>$i18n.fmt('report_nocache')</p>
+	<p>
+	#if $status == 'first'
+		$i18n.fmt('report_first_run')
+		#if $query_runtime > 0
+			$i18n.fmt('report_cold_cache_running', {'runtime': $i18n.format_duration($query_runtime) })
+		#else
+			$i18n.fmt('report_cold_cache_started')
+		#end if
+	#else
+		$i18n.fmt('report_nocache')
+	#end if
+	</p>
 #end def
 
 #end filter


### PR DESCRIPTION
This branch shows a welcome page that notes no data is available yet when the report is being run for the first time.
