### PR TITLE
REPORTS-67 Added comment to running queries with metadata

### DIFF
--- a/python/Reports.py
+++ b/python/Reports.py
@@ -123,7 +123,10 @@ class Report:
     def execute(self, context, dbname, variables):
         db = repdb.connect_wiki(context, dbname)
         c = db.cursor()
-        c.execute(self.query, variables)
+        import re
+        esc_report_title = re.sub(r"[^A-Za-z0-9_@]", "_", "%s@%s" % (self.key, dbname))
+        comment = "/* %s SLOW_OK LIMIT:86400 */" % esc_report_title
+        c.execute(comment + self.query, variables)
         desc = c.description
 
         res = []


### PR DESCRIPTION
The comment contains:
- report key & target wiki
- SLOW_OK
- LIMIT:86400 (24 hours)

The report key and target wiki are escaped using a simple character
whitelist (a-z, A-Z, 0-9, _, @) because mysql_real_escape_string does
not prevent SQL injection in comments.
