### PR TITLE
Load jQuery and jQuery UI from cdnjs mirror

### DIFF
--- a/python/templates/ReportBase.tmpl
+++ b/python/templates/ReportBase.tmpl
@@ -20,10 +20,10 @@ No title
 	<head>
 		<title>$title - tsreports</title>
 		<link rel="stylesheet" href="common.css" type="text/css">
-		<link rel="stylesheet" type="text/css" href="//tools.wmflabs.org/static/res/jquery-ui/1.11.1/jquery-ui.min.css" />
+		<link rel="stylesheet" type="text/css" href="//tools-static.wmflabs.org/cdnjs/ajax/libs/jqueryui/1.11.1/jquery-ui.min.css" />
                 <link rel="stylesheet" type="text/css" href="$context.docroot/chosen.css" />
-		<script type="text/javascript" src="//tools.wmflabs.org/static/res/jquery/1.11.0/jquery.min.js"></script>
-		<script type="text/javascript" src="//tools.wmflabs.org/static/res/jquery-ui/1.11.1/jquery-ui.min.js"></script>
+		<script type="text/javascript" src="//tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+		<script type="text/javascript" src="//tools-static.wmflabs.org/cdnjs/ajax/libs/jqueryui/1.11.1/jquery-ui.min.js"></script>
 		<script type="text/javascript" src="$context.docroot/chosen.jquery.js"></script>
 		<script type="text/javascript" src="$context.docroot/reports.js"></script>
 		<script type="text/javascript">


### PR DESCRIPTION
"the CDNJS one is certainly faster than /static was":
https://lists.wikimedia.org/pipermail/labs-l/2015-June/003764.html
